### PR TITLE
Add search by image URL using an image

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,3 @@ We decided on a GitFlow approach. We have master as our main branch and then hav
     <li> Basic search by query </li>
     <li> Pagination </li>
 </ul>
-### Installing
-```git clone the repository.
-```cd UX-Search\
-```npm update

--- a/README.md
+++ b/README.md
@@ -18,3 +18,7 @@ We decided on a GitFlow approach. We have master as our main branch and then hav
     <li> Basic search by query </li>
     <li> Pagination </li>
 </ul>
+### Installing
+```git clone the repository.
+```cd UX-Search\
+```npm update

--- a/displayimage.js
+++ b/displayimage.js
@@ -121,8 +121,6 @@ function sendRequestToMrEdmond($, mrEdmondResponse, clientResponse) {
         $('#maxPageNumber').text(`${pageCount}`);
 
         console.log("Ending prior to use");
-        var result = adobeMode ? $('#check_id').prop("checked", true): $('#check_id').prop("checked", false);
-        console.log($("#check_id").attr("checked", "checked"));
         clientResponse.write($.html());
         clientResponse.end();
     });

--- a/displayimage.js
+++ b/displayimage.js
@@ -1,7 +1,8 @@
 var https = require("https");
 var http = require("http");
+var cheerio = require('cheerio');
 // Workaround for storing page info.
-const adobeMode = true;
+var adobeMode = false;
 const imagesPerPage = adobeMode ? 64 : 100;
 
 /**
@@ -167,7 +168,6 @@ function getNumberOfResults(response) {
 var fs = require('fs');
 var url = require('url');
 var querystring = require('querystring');
-var cheerio = require('cheerio');
 function display_image() {
     http.createServer(function (request, response) {
         if (request.method === "POST") {
@@ -190,6 +190,10 @@ function display_image() {
                     let webHtmlPage = fs.readFileSync("index.html").toString();
                     var $ = cheerio.load(webHtmlPage);
 
+                    //get the adobe checkbox
+                    adobeMode = $('input[type="checkbox"]').prop('checked')? true : false;
+                    console.log($('#check_id').is(":checked"));
+                    console.log("AdobeMode: " + adobeMode);
                     // Add the orginal query back to the box.
                     if (formData['SearchQuery']) {
                         $('#query').val(formData['SearchQuery']);

--- a/displayimage.js
+++ b/displayimage.js
@@ -77,7 +77,11 @@ function sendRequestToMrEdmond($, mrEdmondResponse, clientResponse) {
         // Add the javascript to the images
         for (let thumbnailName in thumbnails) {
             if (thumbnails[thumbnailName].hasOwnProperty("attribs") && thumbnails[thumbnailName]["attribs"].hasOwnProperty("src")) {
-                thumbnails.get(thumbnailName).attribs['onmouseover'] = `console.log(this.getAttribute('src'));`
+                thumbnails.get(thumbnailName).attribs['onclick'] = `
+                document.getElementById('urlQuery').value = this.getAttribute('src');
+                // console.log(document.getElementById('urlQuery').value);
+                document.getElementById('mainForm').submit();
+                `
             }
         }
 

--- a/displayimage.js
+++ b/displayimage.js
@@ -71,7 +71,15 @@ function sendRequestToMrEdmond($, mrEdmondResponse, clientResponse) {
         
         // Write images
         let thumbnailList = getThumbnails(body);
-        $('#imageDiv').append(thumbnailList);
+        let thumbnailsHtml = $('#imageDiv').append(thumbnailList);
+        let thumbnails = thumbnailsHtml.children();
+
+        // Add the javascript to the images
+        for (let thumbnailName in thumbnails) {
+            if (thumbnails[thumbnailName].hasOwnProperty("attribs") && thumbnails[thumbnailName]["attribs"].hasOwnProperty("src")) {
+                thumbnails.get(thumbnailName).attribs['onmouseover'] = `console.log(this.getAttribute('src'));`
+            }
+        }
 
         // Write page numbers
 

--- a/displayimage.js
+++ b/displayimage.js
@@ -2,7 +2,7 @@ var https = require("https");
 var http = require("http");
 var cheerio = require('cheerio');
 // Workaround for storing page info.
-var adobeMode = false;
+var adobeMode = true;
 const imagesPerPage = adobeMode ? 64 : 100;
 
 /**
@@ -121,6 +121,8 @@ function sendRequestToMrEdmond($, mrEdmondResponse, clientResponse) {
         $('#maxPageNumber').text(`${pageCount}`);
 
         console.log("Ending prior to use");
+        var result = adobeMode ? $('#check_id').prop("checked", true): $('#check_id').prop("checked", false);
+        console.log($("#check_id").attr("checked", "checked"));
         clientResponse.write($.html());
         clientResponse.end();
     });
@@ -191,9 +193,8 @@ function display_image() {
                     var $ = cheerio.load(webHtmlPage);
 
                     //get the adobe checkbox
-                    adobeMode = $('input[type="checkbox"]').prop('checked')? true : false;
-                    console.log($('#check_id').is(":checked"));
-                    console.log("AdobeMode: " + adobeMode);
+                    adobeMode = formData['adobe'] ? true : false;
+                    //console.log("AdobeMode: " + adobeMode);
                     // Add the orginal query back to the box.
                     if (formData['SearchQuery']) {
                         $('#query').val(formData['SearchQuery']);

--- a/displayimage.js
+++ b/displayimage.js
@@ -2,7 +2,7 @@ var https = require("https");
 var http = require("http");
 var cheerio = require('cheerio');
 // Workaround for storing page info.
-var adobeMode = true;
+const adobeMode = true;
 const imagesPerPage = adobeMode ? 64 : 100;
 
 /**
@@ -191,10 +191,6 @@ function display_image() {
                     // Read the HTML file and select key positions in the file.
                     let webHtmlPage = fs.readFileSync("index.html").toString();
                     var $ = cheerio.load(webHtmlPage);
-
-                    //get the adobe checkbox
-                    adobeMode = formData['adobe'] ? true : false;
-                    //console.log("AdobeMode: " + adobeMode);
                     // Add the orginal query back to the box.
                     if (formData['SearchQuery']) {
                         $('#query').val(formData['SearchQuery']);

--- a/index.html
+++ b/index.html
@@ -6,9 +6,6 @@
     <body>
         <div align="center">
             <form method="POST" id="mainForm" action="http://localhost:8888/">
-                <input type="checkbox" name="adobe" id="adobe" style="position:center;left:20%;right:20%;vertical-align:20%;"/>
-                <label for="adobe" checked="" style="position:center;left:20%;right:20%;vertical-align:20%;">Adobe Search</label>
-                <br>
                 <label for="SearchQuery"> Search it: </label>
                 <input type="search" name="SearchQuery" id="query" onkeydown="
                 if (event.keyCode === 13) {

--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@
     <body>
         <div align="center">
             <form method="POST" id="mainForm" action="http://localhost:8888/">
-                <input type="checkbox" name="adobe" id="adobe" style="position:center;left:20%;right:20%;vertical-align:20%;">
-                <label for="adobe" style="position:center;left:20%;right:20%;vertical-align:20%;">Adobe Search</label>
+                <input type="checkbox" name="adobe" id="adobe" style="position:center;left:20%;right:20%;vertical-align:20%;"/>
+                <label for="adobe" checked="" style="position:center;left:20%;right:20%;vertical-align:20%;">Adobe Search</label>
                 <br>
                 <label for="SearchQuery"> Search it: </label>
                 <input type="search" name="SearchQuery" id="query" onkeydown="

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     </head>
     <body>
         <div align="center">
-            <form method="POST" action="http://localhost:8888/">
+            <form method="POST" id="mainForm" action="http://localhost:8888/">
                 <label for="SearchQuery"> Search it: </label>
                 <input type="search" name="SearchQuery" id="query" onkeydown="
                 if (event.keyCode === 13) {
@@ -22,6 +22,7 @@
                     pageBox.value = 1;
                 }
                 ">
+                <input type="hidden" name="URLQuery" id="urlQuery">
                 <div align="left" id="imageDiv">
                 </div>
                 <div id="pageNumberArea">

--- a/index.html
+++ b/index.html
@@ -6,6 +6,9 @@
     <body>
         <div align="center">
             <form method="POST" id="mainForm" action="http://localhost:8888/">
+                <input type="checkbox" name="adobe" id="adobe" style="position:center;left:20%;right:20%;vertical-align:20%;">
+                <label for="adobe" style="position:center;left:20%;right:20%;vertical-align:20%;">Adobe Search</label>
+                <br>
                 <label for="SearchQuery"> Search it: </label>
                 <input type="search" name="SearchQuery" id="query" onkeydown="
                 if (event.keyCode === 13) {


### PR DESCRIPTION
Add image search by clicking on an image, where the URL is taken in as part of a full query by our server.  Our server then makes a request to the Adobe Stock API.  Solves #11.

### Important changes:
*  Queries are now an Object that contains important pieces for constructing full search results.
*  Clicking an image will make the URL a part of this full query object.
*  Adobe Stock's API is now being used for making requests.  A boolean constant can be changed to revert back to Andy Edmond's server.
*  Images are part of the 'result-image' class.  CSS styling suggestions will be gladly taken.
